### PR TITLE
Attempt to pass cookies to other services #61

### DIFF
--- a/polarion/polarion.py
+++ b/polarion/polarion.py
@@ -83,11 +83,13 @@ class Polarion(object):
                 self.services['Session']['url'] + '?wsdl', plugins=[self.history], transport=self._getTransport())
             try:
                 self.sessionHeaderElement = None
+                self.sessionCookieJar = None
                 self.services['Session']['client'].service.logIn(
                     self.user, self.password)
                 tree = self.history.last_received['envelope'].getroottree()
                 self.sessionHeaderElement = tree.find(
                     './/{http://ws.polarion.com/session}sessionID')
+                self.sessionCookieJar = self.services['Session']['client'].transport.session.cookies
             except Exception:
                 raise Exception(
                     f'Could not log in to Polarion for user {self.user}')
@@ -110,6 +112,7 @@ class Polarion(object):
                         self.services[service]['url'] + '?wsdl', transport=self._getTransport())
                 self.services[service]['client'].set_default_soapheaders(
                     [self.sessionHeaderElement])
+                self.services[service]['client'].transport.session.cookies = self.sessionCookieJar
             if service == 'Tracker':
                 if hasattr(self.services[service]['client'].service, 'addComment'):
                     # allow addComment to be send without title, needed for reply comments


### PR DESCRIPTION
Hi, 

It seems like this fix hasn't made it to the release, as we can still reproduce the problem sometimes. 

Did you maybe forget to merge it? We still see the not authorized errors:

```
>>> import os 
>>> POLARION_URL = "https://alm.agcocorp.com/polarion"
>>> POLARION_USER = os.getenv("POLARION_USER")
>>> POLARION_PASSWORD = os.getenv("POLARION_PASSWORD")
>>> 
>>> 
>>> from polarion import polarion
>>> client = polarion.Polarion(POLARION_URL, POLARION_USER, POLARION_PASSWORD)
>>> project = client.getProject('SharedServices')
>>> project = client.getProject('SharedServices')
>>> project = client.getProject('SharedServices')
>>> project = client.getProject('SharedServices')
>>> project = client.getProject('SharedServices')
>>> project = client.getProject('SharedServices')
>>> project = client.getProject('SharedServices')
>>> project = client.getProject('SharedServices')
>>> workitem = project.getWorkitem('SS-1048')
Traceback (most recent call last):
  File "/home/ramona/.virtualenvs/polarion/lib/python3.9/site-packages/polarion/workitem.py", line 51, in __init__
    self._polarion_item = service.getWorkItemById(
  File "/home/ramona/.virtualenvs/polarion/lib/python3.9/site-packages/zeep/proxy.py", line 46, in __call__
    return self._proxy._binding.send(
  File "/home/ramona/.virtualenvs/polarion/lib/python3.9/site-packages/zeep/wsdl/bindings/soap.py", line 135, in send
    return self.process_reply(client, operation_obj, response)
  File "/home/ramona/.virtualenvs/polarion/lib/python3.9/site-packages/zeep/wsdl/bindings/soap.py", line 229, in process_reply
    return self.process_error(doc, operation)
  File "/home/ramona/.virtualenvs/polarion/lib/python3.9/site-packages/zeep/wsdl/bindings/soap.py", line 329, in process_error
    raise Fault(
zeep.exceptions.Fault: Not authorized.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ramona/.virtualenvs/polarion/lib/python3.9/site-packages/polarion/project.py", line 64, in getWorkitem
    return Workitem(self.polarion, self, id)
  File "/home/ramona/.virtualenvs/polarion/lib/python3.9/site-packages/polarion/workitem.py", line 54, in __init__
    raise Exception(
Exception: Cannot find workitem SS-1048 in project SharedServices
>>> workitem = project.getWorkitem('SS-1048')
Traceback (most recent call last):
  File "/home/ramona/.virtualenvs/polarion/lib/python3.9/site-packages/polarion/workitem.py", line 51, in __init__
    self._polarion_item = service.getWorkItemById(
  File "/home/ramona/.virtualenvs/polarion/lib/python3.9/site-packages/zeep/proxy.py", line 46, in __call__
    return self._proxy._binding.send(
  File "/home/ramona/.virtualenvs/polarion/lib/python3.9/site-packages/zeep/wsdl/bindings/soap.py", line 135, in send
    return self.process_reply(client, operation_obj, response)
  File "/home/ramona/.virtualenvs/polarion/lib/python3.9/site-packages/zeep/wsdl/bindings/soap.py", line 229, in process_reply
    return self.process_error(doc, operation)
  File "/home/ramona/.virtualenvs/polarion/lib/python3.9/site-packages/zeep/wsdl/bindings/soap.py", line 329, in process_error
    raise Fault(
zeep.exceptions.Fault: Not authorized.
```

Thanks!

