### PR TITLE
Fix minor typo

### DIFF
--- a/docs/workitem.rst
+++ b/docs/workitem.rst
@@ -17,7 +17,7 @@ A new workitem can be created using :func:`~Project.createWorkitem`.
     new_task = project.createWorkitem('changerequest')
 
     # Add fields to the creation. Needed if there are required fields upon creation.
-    new_task = project..createWorkitem('task', new_workitem_fields={'title': 'New title'})
+    new_task = project.createWorkitem('task', new_workitem_fields={'title': 'New title'})
 
 Updating a field
 ^^^^^^^^^^^^^^^^


### PR DESCRIPTION
```py
new_task = project..createWorkitem('task', new_workitem_fields={'title': 'New title'})
```

should read
```py
new_task = project.createWorkitem('task', new_workitem_fields={'title': 'New title'})
```