### PR TITLE
Avoid exception when test case have empty step content

### DIFF
--- a/polarion/workitem.py
+++ b/polarion/workitem.py
@@ -124,9 +124,10 @@ class Workitem(CustomFields, Comments):
                     # now parse the rows
                     for row in self._polarion_test_steps.steps.TestStep:
                         current_row = {}
-                        for col_id in range(len(row.values.Text)):
-                            current_row[columns[col_id]] = row.values.Text[col_id].content
-                        self._parsed_test_steps.append(current_row)
+                        if row.values is not None:
+                            for col_id in range(len(row.values.Text)):
+                                current_row[columns[col_id]] = row.values.Text[col_id].content
+                            self._parsed_test_steps.append(current_row)
         else:
             raise Exception(f'Workitem not retrieved from Polarion')
 


### PR DESCRIPTION
Currently when you try to parse a test case work item that contains an empty step 
![image](https://github.com/jesper-raemaekers/python-polarion/assets/39908763/ee20c7b8-b722-49e5-9e6c-27ba7a549225)

![image](https://github.com/jesper-raemaekers/python-polarion/assets/39908763/6fae4d9e-d3f9-4f1e-9725-bef032a03d98)


The following exception is raised at workitem.py:

``` text
   for col_id in range(len(row.values.Text)):
AttributeError: 'NoneType' object has no attribute 'Text'
```

The `_buildWorkitemFromPolarion` method does not check if `row.Values` is None:
``` python
    # now parse the rows
    for row in self._polarion_test_steps.steps.TestStep:
        current_row = {}
        for col_id in range(len(row.values.Text)):
            current_row[columns[col_id]] = row.values.Text[col_id].content
        self._parsed_test_steps.append(current_row)
```

A simple validation can be added to handle the exception:
``` python
    # now parse the rows
    for row in self._polarion_test_steps.steps.TestStep:
        current_row = {}
        if row.values is not None:
            for col_id in range(len(row.values.Text)):
                current_row[columns[col_id]] = row.values.Text[col_id].content
            self._parsed_test_steps.append(current_row)
```



