### PR TITLE
Don't package tests directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setuptools.setup(
         "Development Status :: 3 - Alpha"
     ],
     install_requires=["zeep", "lxml", "texttable"],
-    packages=setuptools.find_packages(include=["polarion"]),
+    packages=setuptools.find_packages(include=["polarion*"]),
     python_requires='>=3.7',
 )

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setuptools.setup(
         "Development Status :: 3 - Alpha"
     ],
     install_requires=["zeep", "lxml", "texttable"],
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(include=["polarion"]),
     python_requires='>=3.7',
 )


### PR DESCRIPTION
The `setuptools.find_packages` command will by default find all Python packages starting at the root directory, which in this case includes the `tests` directory. That means that a `tests` package gets installed into your `site-packages` when you install this. That can then cause problems if a user is using `pytest --import-mode=append tests` in order to test an installed version of a package that they are working on that depends on `polarion`, as that will put the users `tests` directory at the end of `sys.path`, and instead the installed `polarion` package tests directory will be searched.

I don't believe there is any reason to ship the tests with the package, so limit the included packages to only include what is necessary when building the package.